### PR TITLE
Properly link a named export for Embroider support

### DIFF
--- a/app/helpers/fn.js
+++ b/app/helpers/fn.js
@@ -1,1 +1,1 @@
-export { default, fn } from 'ember-fn-helper-polyfill/helpers/fn';
+export { default, default as fn } from 'ember-fn-helper-polyfill/helpers/fn';


### PR DESCRIPTION
Embroider flags the `fn` export in an app I'm switching over to Embroider due to the lack of a named `fn` export here. Happy to adjust this in other ways if you'd like to?